### PR TITLE
Don't ignore RequestCustomDomain Extension

### DIFF
--- a/includes/RequestManager.php
+++ b/includes/RequestManager.php
@@ -26,10 +26,6 @@ use Wikimedia\Rdbms\SelectQueryBuilder;
 
 class RequestManager {
 
-	private const IGNORED_USERS = [
-		'RequestCustomDomain Extension',
-	];
-
 	private IDatabase $dbw;
 	private stdClass|false $row;
 
@@ -86,10 +82,7 @@ class RequestManager {
 			->caller( __METHOD__ )
 			->execute();
 
-		if (
-			ExtensionRegistry::getInstance()->isLoaded( 'Echo' ) &&
-			!in_array( $user->getName(), self::IGNORED_USERS )
-		) {
+		if ( ExtensionRegistry::getInstance()->isLoaded( 'Echo' ) ) {
 			$this->sendNotification( $comment, 'requestcustomdomain-request-comment', $user );
 		}
 	}


### PR DESCRIPTION
This has the other effect of sending notifications for users own edits sometimes, but its a worthy trade-off as with this ignored they also dont get notified when Cloudflare reports the domain is not pointed. The alternative option to this us have the Cloudflare job post comments using RequestCustomDomain Status Update instead.